### PR TITLE
Add driver script for running benchmarks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,11 @@ genx:
 	julia --project=GenX GenX/main.jl --all --run --write
 
 benchmark:
+	@if [ ${HIGHS} ]; then\
+		echo ${HIGHS};\
+		julia --project=benchmark -e 'import Pkg; Pkg.add(; name = "HiGHS_jll", version = ENV["HIGHS"])';\
+    fi
+	julia --project=benchmark -e "import Pkg; Pkg.instantiate()"
 	julia --project=benchmark benchmark/main.jl --all
 
 analyze:

--- a/Makefile
+++ b/Makefile
@@ -7,12 +7,20 @@ default: help
 
 help:
 	@echo "The following make commands are available:"
-	@echo "  genx   write all GenX instances"
-	@echo "  all    re-run all commands"
+	@echo "  genx   	write all GenX instances"
+	@echo "  benchmark  run a new set of benchmarks"
+	@echo "  analyze   	print analysis of output"
+	@echo "  all    	re-run all commands"
 
 genx:
 	julia --project=GenX GenX/main.jl --all --run --write
 
+benchmark:
+	julia --project=benchmark benchmark/main.jl --all
+
+analyze:
+	julia --project=benchmark benchmark/main.jl --analyze
+
 all: genx
 
-.PHONY: default help genx list
+.PHONY: default help genx benchmark analyze

--- a/Makefile
+++ b/Makefile
@@ -7,10 +7,10 @@ default: help
 
 help:
 	@echo "The following make commands are available:"
-	@echo "  genx   	write all GenX instances"
-	@echo "  benchmark  run a new set of benchmarks"
-	@echo "  analyze   	print analysis of output"
-	@echo "  all    	re-run all commands"
+	@echo "  genx     write all GenX instances"
+	@echo "  [HIGHS=X.Y.Z] benchmark  run a new set of benchmarks, optionally with a version of HiGHS"
+	@echo "  analyze  print analysis of output"
+	@echo "  all      re-run all commands"
 
 genx:
 	julia --project=GenX GenX/main.jl --all --run --write

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ This repository is licensed under the [MIT license](https://github.com/jump-dev/
 
 This repository is organized as follows:
 
+ * `/benchmark`: scripts to run any required benchmarking experiments
  * `/instances`: a collection of MPS for benchmarking. Files in this directory
    are gzipped with the default `gzip <file.mps>`. Filenames are the SHA256 of
    the uncompressed MPS file (to mitigate against potential differences in

--- a/benchmark/Project.toml
+++ b/benchmark/Project.toml
@@ -1,4 +1,8 @@
 [deps]
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
-HiGHS = "87dc4568-4c63-4d18-b0c0-bb2238e4078b"
+HiGHS_jll = "8fd58aa0-07eb-5a78-9b36-339c94fd15ea"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+
+[compat]
+DataFrames = "1"
+JSON = "0.21"

--- a/benchmark/Project.toml
+++ b/benchmark/Project.toml
@@ -1,3 +1,4 @@
 [deps]
+DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 HiGHS = "87dc4568-4c63-4d18-b0c0-bb2238e4078b"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"

--- a/benchmark/Project.toml
+++ b/benchmark/Project.toml
@@ -1,0 +1,3 @@
+[deps]
+HiGHS = "87dc4568-4c63-4d18-b0c0-bb2238e4078b"
+JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"

--- a/benchmark/main.jl
+++ b/benchmark/main.jl
@@ -1,0 +1,111 @@
+# Copyright (c) 2024: Oscar Dowson, Joaquim Garcia and contributors
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
+import HiGHS
+import JSON
+
+const INSTANCE_DIR = joinpath(dirname(@__DIR__), "instances")
+
+_is_mps(c) = endswith(c, ".mps.gz")
+
+function print_help()
+    files = readdir(INSTANCE_DIR; sort = false)
+    print(
+        """
+        usage: julia --project=benchmark benchmark/main.jl \
+            --instance=<name> | --all
+            [--help]
+            [--output_file=<data_time.jsonl>]
+            [--option=<value>]
+
+        ## Arguments
+
+         * `--instance`:  the file in `instance` to run. Valid files are
+            * $(join(filter(_is_mps, files), "\n    * "))
+         * `--all`    if passed, `--instance` must not be passed, and the
+                      argument will loop over all valid instances
+         * `--help`   print this help message
+         * `--option=<value>`   option value pairs that are passed directly to
+                                HiGHS
+        """
+    )
+    return
+end
+
+function _parse_args(args)
+    ret = Dict{String,String}()
+    for arg in args
+        if (m = match(r"--([a-z]+)=(.+?)($|\s)", arg)) !== nothing
+            ret[m[1]] = m[2]
+        elseif (m = match(r"--([a-z]+?)($|\s)", arg)) !== nothing
+            ret[m[1]] = "true"
+        else
+            error("unsupported argument $arg")
+        end
+    end
+    return ret
+end
+
+function benchmark(filename, parsed_args)
+    start_time = time()
+    highs = HiGHS.Highs_create()
+    ret = HiGHS.Highs_readModel(highs, filename)
+    @assert ret == 0
+    typeP = Ref{Cint}()
+    for (option, value) in parsed_args
+        if option in ("instance", "all", "help")
+            continue
+        end
+        ret = HiGHS.Highs_getOptionType(highs, option, typeP)
+        if !iszero(ret)
+            # Not an option. Skip.
+        elseif typeP[] == HiGHS.kHighsOptionTypeBool
+            HiGHS.Highs_setBoolOptionValue(highs, option, parse(Cint, value))
+        elseif typeP[] == HiGHS.kHighsOptionTypeInt
+            HiGHS.Highs_setIntOptionValue(highs, option, parse(Cint, value))
+        elseif typeP[] == HiGHS.kHighsOptionTypeDouble
+            HiGHS.Highs_setDoubleOptionValue(highs, option, parse(Float64, value))
+        else
+            @assert typeP[] == HiGHS.kHighsOptionTypeString
+            HiGHS.Highs_setStringOptionValue(highs, option, value)
+        end
+    end
+    run_status = HiGHS.Highs_run(highs)
+    total_time = time() - start_time
+    X = HiGHS.Highs_versionMajor()
+    Y = HiGHS.Highs_versionMinor()
+    Z = HiGHS.Highs_versionPatch()
+    return Dict(
+        "version" => "v$X.$Y.$Z",
+        "julia_total_time" => total_time,
+        "highs_run_time" => HiGHS.Highs_getRunTime(model),
+        "highs_objective_value" => HiGHS.Highs_getObjectiveValue(model),
+        "run_status" => run_status,
+        "model_status" => HiGHS.Highs_getModelStatus(model),
+    )
+end
+
+function main(args)
+    parsed_args = _parse_args(args)
+    if get(parsed_args, "help", "false") == "true"
+        return print_help()
+    end
+    instances = String[]
+    if get(parsed_args, "all", "false") == "true"
+        append!(instances, filter(_is_mps, readdir(INSTANCE_DIR; join = true)))
+    else
+        push!(instances, joinpath(INSTANCE_DIR, parsed_args["instance"]))
+    end
+    for instance in instances
+        ret = benchmark(instance, parsed_args)
+        open("output.jsonl") do io
+            return println(io, JSON.json(ret))
+        end
+    end
+    return
+end
+
+# julia --project=benchmark benchmark/main.jl --instance=09d8dfdaa3dff578cb9f3af8ecefe9dab893a0ada31310c6b4010972415e8b44-GenX_8_three_zones_w_colocated_VRE_storage_electrolyzers.mps.gz --solver=ipm
+main(ARGS)

--- a/benchmark/main.jl
+++ b/benchmark/main.jl
@@ -37,12 +37,14 @@ end
 function _parse_args(args)
     ret = Dict{String,String}()
     for arg in args
-        if (m = match(r"--([a-z]+)=(.+?)($|\s)", arg)) !== nothing
-            ret[m[1]] = m[2]
-        elseif (m = match(r"--([a-z]+?)($|\s)", arg)) !== nothing
-            ret[m[1]] = "true"
+        @assert startswith(arg, "--")
+        arg = arg[3:end]
+        if occursin("=", arg)
+            items = split(arg, "=")
+            @assert length(items) == 2
+            ret[items[1]] = items[2]
         else
-            error("unsupported argument $arg")
+            ret[arg] = "true"
         end
     end
     return ret

--- a/benchmark/main.jl
+++ b/benchmark/main.jl
@@ -57,25 +57,48 @@ end
 function benchmark(filename, parsed_args)
     start_time = time()
     highs = @ccall libhighs.Highs_create()::Ptr{Cvoid}
-    ret = @ccall libhighs.Highs_readModel(highs::Ptr{Cvoid}, filename::Ptr{Cchar})::Cint
+    ret = @ccall libhighs.Highs_readModel(
+        highs::Ptr{Cvoid},
+        filename::Ptr{Cchar},
+    )::Cint
     @assert ret == 0
     typeP = Ref{Cint}()
     for (option, value) in parsed_args
         if option in ("instance", "all", "help")
             continue
         end
-        ret = @ccall libhighs.Highs_getOptionType(highs::Ptr{Cvoid}, option::Ptr{Cchar}, typeP::Ptr{Cint})::Cint
+        ret = @ccall libhighs.Highs_getOptionType(
+            highs::Ptr{Cvoid},
+            option::Ptr{Cchar},
+            typeP::Ptr{Cint},
+        )::Cint
         if !iszero(ret)
             # Not an option. Skip.
         elseif typeP[] == Cint(0)  # kHighsOptionTypeBool
-            @ccall libhighs.Highs_setBoolOptionValue(highs::Ptr{Cvoid}, option::Ptr{Cchar}, parse(Cint, value)::Cint)::Cint
+            @ccall libhighs.Highs_setBoolOptionValue(
+                highs::Ptr{Cvoid},
+                option::Ptr{Cchar},
+                parse(Cint, value)::Cint,
+            )::Cint
         elseif typeP[] == Cint(1)  # kHighsOptionTypeInt
-            @ccall libhighs.Highs_setIntOptionValue(highs::Ptr{Cvoid}, option::Ptr{Cchar}, parse(Cint, value)::Cint)::Cint
+            @ccall libhighs.Highs_setIntOptionValue(
+                highs::Ptr{Cvoid},
+                option::Ptr{Cchar},
+                parse(Cint, value)::Cint,
+            )::Cint
         elseif typeP[] == Cint(2)  # kHighsOptionTypeDouble
-            @ccall libhighs.Highs_setDoubleOptionValue(highs::Ptr{Cvoid}, option::Ptr{Cchar}, parse(Float64, value)::Cdouble)::Cint
+            @ccall libhighs.Highs_setDoubleOptionValue(
+                highs::Ptr{Cvoid},
+                option::Ptr{Cchar},
+                parse(Float64, value)::Cdouble,
+            )::Cint
         else
             @assert typeP[] == Cint(3)  # kHighsOptionTypeString
-            @ccall libhighs.Highs_setStringOptionValue(highs::Ptr{Cvoid}, option::Ptr{Cchar}, value::Ptr{Cchar})::Cint
+            @ccall libhighs.Highs_setStringOptionValue(
+                highs::Ptr{Cvoid},
+                option::Ptr{Cchar},
+                value::Ptr{Cchar},
+            )::Cint
         end
     end
     run_status = @ccall libhighs.Highs_run(highs::Ptr{Cvoid})::Cint
@@ -88,10 +111,13 @@ function benchmark(filename, parsed_args)
         "options" => parsed_args,
         "version" => "v$X.$Y.$Z",
         "julia_total_time" => total_time,
-        "highs_run_time" => @ccall libhighs.Highs_getRunTime(highs::Ptr{Cvoid})::Cdouble,
-        "highs_objective_value" => @ccall libhighs.Highs_getObjectiveValue(highs::Ptr{Cvoid})::Cdouble,
+        "highs_run_time" =>
+            @ccall(libhighs.Highs_getRunTime(highs::Ptr{Cvoid})::Cdouble),
+        "highs_objective_value" =>
+            @ccall(libhighs.Highs_getObjectiveValue(highs::Ptr{Cvoid})::Cdouble),
         "run_status" => run_status,
-        "model_status" => @ccall libhighs.Highs_getModelStatus(highs::Ptr{Cvoid})::Cint,
+        "model_status" =>
+            @ccall(libhighs.Highs_getModelStatus(highs::Ptr{Cvoid})::Cint),
     )
     # INFO
     pType = Ref{Cint}()
@@ -116,11 +142,19 @@ function benchmark(filename, parsed_args)
         Highs_getInfoType(highs, info, pType)
         if pType[] == Cint(1)  # kHighsInfoTypeInt
             pInt = Ref{Cint}()
-            @ccall libhighs.Highs_getIntInfoValue(highs::Ptr{Cvoid}, info::Ptr{Cchar}, pInt::Ptr{Cint})::Cint
+            @ccall libhighs.Highs_getIntInfoValue(
+                highs::Ptr{Cvoid},
+                info::Ptr{Cchar},
+                pInt::Ptr{Cint},
+            )::Cint
             result[info] = pInt[]
         elseif pType[] == Cint(2)  # kHighsInfoTypeDouble
             pDouble = Ref{Cdouble}()
-            @ccall libhighs.Highs_getDoubleInfoValue(highs::Ptr{Cvoid}, info::Ptr{Cchar}, pDouble::Ptr{Cdouble})::Cint
+            @ccall libhighs.Highs_getDoubleInfoValue(
+                highs::Ptr{Cvoid},
+                info::Ptr{Cchar},
+                pDouble::Ptr{Cdouble},
+            )::Cint
             result[info] = pDouble[]
         end
     end

--- a/benchmark/main.jl
+++ b/benchmark/main.jl
@@ -139,7 +139,11 @@ function benchmark(filename, parsed_args)
         "max_dual_infeasibility",
         "sum_dual_infeasibilities",
     ]
-        Highs_getInfoType(highs, info, pType)
+        @ccall libhighs.Highs_getInfoType(
+            highs::Ptr{Cvoid},
+            info::Ptr{Cchar},
+            pType::Ptr{Cint},
+        )::Cint
         if pType[] == Cint(1)  # kHighsInfoTypeInt
             pInt = Ref{Cint}()
             @ccall libhighs.Highs_getIntInfoValue(

--- a/benchmark/main.jl
+++ b/benchmark/main.jl
@@ -82,10 +82,10 @@ function benchmark(filename, parsed_args)
     return Dict(
         "version" => "v$X.$Y.$Z",
         "julia_total_time" => total_time,
-        "highs_run_time" => HiGHS.Highs_getRunTime(model),
-        "highs_objective_value" => HiGHS.Highs_getObjectiveValue(model),
+        "highs_run_time" => HiGHS.Highs_getRunTime(highs),
+        "highs_objective_value" => HiGHS.Highs_getObjectiveValue(highs),
         "run_status" => run_status,
-        "model_status" => HiGHS.Highs_getModelStatus(model),
+        "model_status" => HiGHS.Highs_getModelStatus(highs),
     )
 end
 

--- a/benchmark/main.jl
+++ b/benchmark/main.jl
@@ -93,12 +93,6 @@ function benchmark(filename, parsed_args)
         "run_status" => run_status,
         "model_status" => @ccall libhighs.Highs_getModelStatus(highs::Ptr{Cvoid})::Cint,
     )
-    pBool = Ref{Cint}(0)
-    @ccall libhighs.Highs_getIntInfoValue(highs::Ptr{Cvoid}, "valid"::Ptr{Cchar}, pBool::Ptr{Cint})::Cint
-    if pBool[] == 0
-        @ccall libhighs.Highs_destroy(highs::Ptr{Cvoid})::Cvoid
-        return result
-    end
     # INFO
     pType = Ref{Cint}()
     for info in [

--- a/benchmark/main.jl
+++ b/benchmark/main.jl
@@ -80,6 +80,8 @@ function benchmark(filename, parsed_args)
     Y = HiGHS.Highs_versionMinor()
     Z = HiGHS.Highs_versionPatch()
     return Dict(
+        "filename" => filename,
+        "options" => parsed_args,
         "version" => "v$X.$Y.$Z",
         "julia_total_time" => total_time,
         "highs_run_time" => HiGHS.Highs_getRunTime(highs),
@@ -102,7 +104,7 @@ function main(args)
     end
     for instance in instances
         ret = benchmark(instance, parsed_args)
-        open("output.jsonl") do io
+        open("output.jsonl", "a") do io
             return println(io, JSON.json(ret))
         end
     end


### PR DESCRIPTION
Now I understand why the default settings are changed https://github.com/jump-dev/open-energy-modeling-benchmarks/issues/5

Default is dual simplex
```
(base) oscar@Oscars-MBP open-energy-modeling-benchmarks % julia --project=benchmark benchmark/main.jl --instance=09d8dfdaa3dff578cb9f3af8ecefe9dab893a0ada31310c6b4010972415e8b44-GenX_8_three_zones_w_colocated_VRE_storage_electrolyzers.mps.gz
Running HiGHS 1.7.2 (git hash: 5ce7a2753): Copyright (c) 2024 HiGHS under MIT licence terms
Coefficient ranges:
  Matrix [5e-03, 5e+02]
  Cost   [5e-01, 2e+07]
  Bound  [0e+00, 0e+00]
  RHS    [2e+00, 3e+08]
Presolving model
193417 rows, 166571 cols, 718423 nonzeros  0s
186080 rows, 159234 cols, 722167 nonzeros  0s
Presolve : Reductions: rows 186080(-99569); columns 159234(-91175); elements 722167(-244524)
Solving the presolved LP
Using EKK dual simplex solver - serial
  Iteration        Objective     Infeasibilities num(sum)
          0    -7.1670893480e+05 Ph1: 20161(20852.8); Du: 10080(716709) 1s
       6309    -1.2499719557e+02 Ph1: 6(3.93322); Du: 1(124.997) 6s
       9603    -1.2499682869e+02 Ph1: 6(2.30736); Du: 1(124.997) 11s
      12437    -1.2499648326e+02 Ph1: 5(3.61473); Du: 1(124.996) 16s
      15032    -1.2499611570e+02 Ph1: 8(3.29623); Du: 2(124.996) 21s
      17513    -1.2499568718e+02 Ph1: 18(8.02397); Du: 3(124.996) 27s
      21527    -1.2396651214e+02 Ph1: 12(15.3808); Du: 1(123.967) 32s
      23949    -1.2396631111e+02 Ph1: 10(9.36891); Du: 1(123.966) 38s
```
IPM makes better progress
```
(base) oscar@Oscars-MBP open-energy-modeling-benchmarks % julia --project=benchmark benchmark/main.jl --instance=09d8dfdaa3dff578cb9f3af8ecefe9dab893a0ada31310c6b4010972415e8b44-GenX_8_three_zones_w_colocated_VRE_storage_electrolyzers.mps.gz --solver=ipm
Running HiGHS 1.7.2 (git hash: 5ce7a2753): Copyright (c) 2024 HiGHS under MIT licence terms
Coefficient ranges:
  Matrix [5e-03, 5e+02]
  Cost   [5e-01, 2e+07]
  Bound  [0e+00, 0e+00]
  RHS    [2e+00, 3e+08]
Presolving model
193417 rows, 166571 cols, 718423 nonzeros  0s
186080 rows, 159234 cols, 722167 nonzeros  0s
Presolve : Reductions: rows 186080(-99569); columns 159234(-91175); elements 722167(-244524)
Solving the presolved LP
IPX model has 186080 rows, 159234 columns and 722167 nonzeros
Input
    Number of variables:                                159234
    Number of free variables:                           0
    Number of constraints:                              186080
    Number of equality constraints:                     44743
    Number of matrix entries:                           722167
    Matrix range:                                       [6e-03, 3e+02]
    RHS range:                                          [5e+02, 3e+08]
    Objective range:                                    [5e-01, 2e+07]
    Bounds range:                                       [2e+00, 3e+08]
Preprocessing
    Dualized model:                                     no
    Number of dense columns:                            40
    Range of scaling factors:                           [1.25e-01, 4.00e+00]
IPX version 1.0
Interior Point Solve
 Iter     P.res    D.res            P.obj           D.obj        mu     Time
   0   1.32e+08 1.21e+05   3.85666634e+14 -8.40523648e+15  1.61e+13       0s
   1   1.19e+08 1.15e+05   1.19042833e+15 -8.53131850e+15  1.58e+13       1s
   2   1.14e+08 9.62e+04   1.66132234e+15 -9.09616356e+15  1.55e+13       2s
   3   1.03e+08 8.47e+04   2.85865874e+15 -9.57439700e+15  1.51e+13       3s
   4   2.89e+07 3.79e+04   1.10443687e+16 -1.01441902e+16  7.54e+12       3s
   5   6.99e+06 9.02e+03   1.34900404e+16 -5.80578221e+15  1.90e+12       5s
   6   2.22e+06 7.78e+02   1.07758823e+16 -1.79678742e+15  3.33e+11       7s
 Constructing starting basis...
   7   8.50e+04 6.70e+01   2.72737663e+15 -6.72996361e+14  2.50e+10      13s
   8   7.99e+03 1.16e+01   8.17031984e+14 -1.75132307e+14  4.57e+09      16s
   9   4.30e+03 2.88e+00   5.47384299e+14 -6.27080935e+13  2.32e+09      41s
  10   2.19e+03 1.39e+00   3.37338088e+14 -3.50396207e+13  1.34e+09      50s
```
And they run with
```
(base) oscar@Oscars-MBP open-energy-modeling-benchmarks % julia --project=benchmark benchmark/main.jl --instance=09d8dfdaa3dff578cb9f3af8ecefe9dab893a0ada31310c6b4010972415e8b44-GenX_8_three_zones_w_colocated_VRE_storage_electrolyzers.mps.gz --solver=ipm --ipm_optimality_tolerance=1e-4 --primal_feasibility_tolerance=1e-4 --run_crossover=off
Running HiGHS 1.7.2 (git hash: 5ce7a2753): Copyright (c) 2024 HiGHS under MIT licence terms
Coefficient ranges:
  Matrix [5e-03, 5e+02]
  Cost   [5e-01, 2e+07]
  Bound  [0e+00, 0e+00]
  RHS    [2e+00, 3e+08]
Presolving model
193417 rows, 166571 cols, 718423 nonzeros  0s
186080 rows, 159234 cols, 713431 nonzeros  0s
Presolve : Reductions: rows 186080(-99569); columns 159234(-91175); elements 713431(-253260)
Solving the presolved LP
IPX model has 186080 rows, 159234 columns and 713431 nonzeros
Input
    Number of variables:                                159234
    Number of free variables:                           0
    Number of constraints:                              186080
    Number of equality constraints:                     44743
    Number of matrix entries:                           713431
    Matrix range:                                       [1e-02, 3e+02]
    RHS range:                                          [5e+02, 3e+08]
    Objective range:                                    [5e-01, 2e+07]
    Bounds range:                                       [2e+00, 3e+08]
Preprocessing
    Dualized model:                                     no
    Number of dense columns:                            40
    Range of scaling factors:                           [1.25e-01, 4.00e+00]
IPX version 1.0
Interior Point Solve
 Iter     P.res    D.res            P.obj           D.obj        mu     Time
   0   1.32e+08 1.21e+05   3.86393282e+14 -8.40355954e+15  1.61e+13       0s
   1   1.19e+08 1.15e+05   1.02485436e+15 -8.52922599e+15  1.58e+13       2s
   2   1.14e+08 9.69e+04   1.43685477e+15 -9.06843832e+15  1.55e+13       3s
   3   1.03e+08 8.47e+04   2.49158742e+15 -9.56747357e+15  1.51e+13       3s
   4   2.93e+07 3.80e+04   1.04726505e+16 -1.00995635e+16  7.56e+12       4s
   5   5.82e+06 7.43e+03   1.36103022e+16 -5.53138279e+15  1.56e+12       6s
   6   2.37e+06 8.58e+02   1.08252572e+16 -1.81125889e+15  3.61e+11       8s
 Constructing starting basis...
   7   8.73e+04 7.12e+01   2.90611737e+15 -6.80994893e+14  2.66e+10      18s
   8   8.66e+03 2.81e+01   9.15318057e+14 -3.17153750e+14  7.16e+09      23s
   9   4.01e+03 4.71e+00   6.21964396e+14 -8.66311830e+13  2.83e+09      38s
  10   1.91e+03 1.99e+00   3.76414524e+14 -4.58304135e+13  1.55e+09      52s
  11   8.81e+02 1.00e+00   2.53927232e+14 -2.91909351e+13  9.99e+08      64s
```